### PR TITLE
Revert to actions/cache@v2 for Bazel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
   Bazel:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/cache@v3
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-Bazel


### PR DESCRIPTION
Looks like there is some cache issue with the v3 cache version.