### PR TITLE
Fix version update targets.

### DIFF
--- a/tools/version_update.sh
+++ b/tools/version_update.sh
@@ -16,7 +16,7 @@ for spec in ${version_specs[@]}; do
   url="$(sed "s/${version}/${upstream_version}/g" <<< "${url}")"
   tmp="$(mktemp)"
 
-  curl "${url}" --output "${tmp}" --silent
+  curl "${url}" --output "${tmp}" --silent --location
 
   checksum="$(sha256sum "${tmp}" | awk '{ print $1 }')"
 


### PR DESCRIPTION
Tell `curl` to follow redirects to construct the right checksum.