### PR TITLE
Add missing pre_js.d.ts

### DIFF
--- a/tools/emscripten/pre_js.d.ts
+++ b/tools/emscripten/pre_js.d.ts
@@ -1,0 +1,16 @@
+// Additional Emscripten type declarations.
+
+const { Emscripten, EmscriptenModule } = require("@types/emscripten");
+
+// Global Module object, available to scripts in --pre-js and --post-js:
+const Module: EmscriptenModule;
+
+// Additional free functions that are not necessarily exported on the module object:
+const {
+    HEAPU8,
+    _free,
+    _malloc,
+} = Emscripten;
+
+// Additional functions missing from @types/emscripten:
+declare function getNativeTypeSize(type: Emscripten.CType): number;


### PR DESCRIPTION
This file was renamed from types.d.ts in f863248, but I forgot to commit the renamed file so it got lost somewhere. It is not currently used though, but at least the build should not fail.

With chis change, `bazel build //...` should pass.