### PR TITLE
Add bootstrap dependencies to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,8 @@
 with import <nixpkgs> {};
-clangStdenv.mkDerivation {
-  name = "clang-nix-shell";
-  buildInputs = [];
+(mkShell.override { stdenv = llvmPackages_16.stdenv; }) {
+  buildInputs = [
+    pkg-config
+    openssl
+    zlib
+  ];
 }


### PR DESCRIPTION
Overall, make dependency resolution work by using the pkg-config provided by Nix.